### PR TITLE
Add functionality to propagate bans between two subreddits

### DIFF
--- a/banusers.py
+++ b/banusers.py
@@ -1,0 +1,36 @@
+"""
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""
+
+import praw
+
+def getbanned (r: praw.Reddit, subreddit: str) -> list :
+    """
+    Fetch banned users from a subreddit.
+
+    Due to a Reddit API limitation this will fetch at most 100 users.
+    """
+    bannedlist = []
+    for user in r.subreddit(subreddit).banned() :
+        bannedlist.append(user.name)
+    return bannedlist
+
+def banusers (r : praw.Reddit, list: list, subreddit: str) -> None :
+    """
+    Mass-ban a list of users from a subreddit. Skips users that are already banned.
+    """
+    for user in list :
+        if user not in r.subreddit(subreddit).banned() :
+            r.subreddit('c4crep').banned.add(user)
+            print ("Banned", user)

--- a/banusers.py
+++ b/banusers.py
@@ -14,6 +14,7 @@
 """
 
 import praw
+import json
 
 def getbanned (r: praw.Reddit, subreddit: str) -> list :
     """
@@ -34,3 +35,23 @@ def banusers (r : praw.Reddit, list: list, subreddit: str) -> None :
         if user not in r.subreddit(subreddit).banned() :
             r.subreddit('c4crep').banned.add(user)
             print ("Banned", user)
+
+def writebanned (list: list, filename: str = 'banned.json') -> None :
+    """
+    Write the list of banned users to the disk
+
+    This will overwrite the file if it exists.
+    """
+    try :
+        with open(filename, 'x') as f :
+            json.dump(list, f)
+    except FileExistsError : #janky but functional solution to avoid importing the os library
+        with open(filename, 'w') as f :
+            json.dump(list, f)
+
+def readbanned (filename: str = 'banned.json') -> list :
+    """
+    Read the list of banned users from the disk
+    """
+    with open(filename, "r") as f :
+        return json.load(f)


### PR DESCRIPTION
This pull request implements the functionality to propagate bans between two subreddits, stored in the `banusers` module. It contains four functions:

- `getbanned`: returns a `list` of usernames (`str`) that are banned from a given subreddit. Takes in a `praw.Reddit` instance and the subreddit to fetch from (`str`). Due to a Reddit API limitation, this maxes out at 100 users.
- `banusers`: Bans a `list` of users (can be `str` or `praw.Redditor`) from a subreddit (`str`). Requires a `praw.Reddit` instance to be passed in.
- `writebanned`: Writes a `list` of usernames to the disk. By default, it writes to a file called "banned.json", but this can be changed with an optional parameter
- `readbanned`: Reads a `list` of usernames from the disk. By default, it reads from a file called "banned.json", but this can be changed with an optional parameter.

This PR does not use the functions in any way; it only defines them, but it provides them in a ready-to-eat format for use in other files.